### PR TITLE
Updated Tagged Data Container

### DIFF
--- a/ArcActivities/Source/ArcActivitiesPlugin/Private/ArcActivityBPFunctionLibrary.cpp
+++ b/ArcActivities/Source/ArcActivitiesPlugin/Private/ArcActivityBPFunctionLibrary.cpp
@@ -11,6 +11,7 @@ int32 UArcActivityBPFunctionLibrary::GetTaggedDataAsInt(UArcActivityInstance* Ac
 	{
 		if (auto Value = Activity->GetTaggedData<int32>(Tag))
 		{
+			Found = true;
 			return *Value;
 		}
 	}
@@ -24,6 +25,7 @@ float UArcActivityBPFunctionLibrary::GetTaggedDataAsFloat(UArcActivityInstance* 
 	{
 		if (auto Value = Activity->GetTaggedData<float>(Tag))
 		{
+			Found = true;
 			return *Value;
 		}
 	}
@@ -38,6 +40,7 @@ double UArcActivityBPFunctionLibrary::GetTaggedDataAsDouble(UArcActivityInstance
 	{
 		if (auto Value = Activity->GetTaggedData<double>(Tag))
 		{
+			Found = true;
 			return *Value;
 		}
 	}
@@ -52,6 +55,7 @@ FGameplayTag UArcActivityBPFunctionLibrary::GetTaggedDataAsGameplayTag(UArcActiv
 	{
 		if (auto Value = Activity->GetTaggedData<FGameplayTag>(Tag))
 		{
+			Found = true;
 			return *Value;
 		}
 	}
@@ -66,6 +70,7 @@ FVector UArcActivityBPFunctionLibrary::GetTaggedDataAsFVector(UArcActivityInstan
 	{
 		if (auto Value = Activity->GetTaggedData<FVector>(Tag))
 		{
+			Found = true;
 			return *Value;
 		}
 	}
@@ -82,6 +87,7 @@ AActor* UArcActivityBPFunctionLibrary::GetTaggedDataAsActor(UArcActivityInstance
 		{
 			if (Value->IsValid())
 			{
+				Found = true;
 				return Value->Get();
 			}
 		}
@@ -169,5 +175,140 @@ bool UArcActivityBPFunctionLibrary::HasTaggedDataAsFVector(UArcActivityInstance*
 bool UArcActivityBPFunctionLibrary::HasTaggedDataAsActor(UArcActivityInstance* Activity, FGameplayTag Tag)
 {
 	return IsValid(Activity) && Activity->HasTaggedData<TWeakObjectPtr<AActor>>(Tag);
+}
+
+int32 UArcActivityBPFunctionLibrary::GetPreviousTaggedDataAsInt_Event(const FArcActivityTagStackChanged& Event,
+	bool& Found)
+{
+	if (auto Value = Event.PreviousValue.TryGet<int32>())
+	{
+		Found = true;
+		return *Value;
+	}
+	Found = false;
+	return {};
+}
+
+float UArcActivityBPFunctionLibrary::GetPreviousTaggedDataAsFloat_Event(const FArcActivityTagStackChanged& Event,
+	bool& Found)
+{
+	if (auto Value = Event.PreviousValue.TryGet<float>())
+	{
+		Found = true;
+		return *Value;
+	}
+	Found = false;
+	return {};
+}
+
+double UArcActivityBPFunctionLibrary::GetPreviousTaggedDataAsDouble_Event(const FArcActivityTagStackChanged& Event,
+	bool& Found)
+{
+	if (auto Value = Event.PreviousValue.TryGet<double>())
+	{
+		Found = true;
+		return *Value;
+	}
+	Found = false;
+	return {};
+}
+
+FGameplayTag UArcActivityBPFunctionLibrary::GetPreviousTaggedDataAsGameplayTag_Event(
+	const FArcActivityTagStackChanged& Event, bool& Found)
+{
+	if (auto Value = Event.PreviousValue.TryGet<FGameplayTag>())
+	{
+		Found = true;
+		return *Value;
+	}
+	Found = false;
+	return {};
+}
+
+FVector UArcActivityBPFunctionLibrary::GetPreviousTaggedDataAsFVector_Event(const FArcActivityTagStackChanged& Event,
+	bool& Found)
+{
+	if (auto Value = Event.PreviousValue.TryGet<FVector>())
+	{
+		Found = true;
+		return *Value;
+	}
+	Found = false;
+	return {};
+}
+
+AActor* UArcActivityBPFunctionLibrary::GetPreviousTaggedDataAsActor_Event(const FArcActivityTagStackChanged& Event,
+	bool& Found)
+{
+	if (auto Value = Event.PreviousValue.TryGet<TWeakObjectPtr<AActor>>();
+		Value != nullptr && Value->IsValid())
+	{		
+		Found = true;
+		return Value->Get();			
+	}
+	Found = false;
+	return {};
+}
+
+void UArcActivityBPFunctionLibrary::SetIntPreviousTaggedData_Event(FArcActivityTagStackChanged& Event, int32 Value)
+{
+	Event.PreviousValue = FTaggedDataVariant(TInPlaceType<int32>{}, Value);
+}
+
+void UArcActivityBPFunctionLibrary::SetFloatPreviousTaggedData_Event(FArcActivityTagStackChanged& Event, float Value)
+{
+	Event.PreviousValue = FTaggedDataVariant(TInPlaceType<float>{}, Value);
+}
+
+void UArcActivityBPFunctionLibrary::SetDoublePreviousTaggedData_Event(FArcActivityTagStackChanged& Event, double Value)
+{
+	Event.PreviousValue = FTaggedDataVariant(TInPlaceType<double>{}, Value);
+}
+
+void UArcActivityBPFunctionLibrary::SetGameplayTagPreviousTaggedData_Event(FArcActivityTagStackChanged& Event,
+	FGameplayTag Value)
+{
+	Event.PreviousValue = FTaggedDataVariant(TInPlaceType<FGameplayTag>{}, Value);
+}
+
+void UArcActivityBPFunctionLibrary::SetFVectorPreviousTaggedData_Event(FArcActivityTagStackChanged& Event,
+	FVector Value)
+{
+	Event.PreviousValue = FTaggedDataVariant(TInPlaceType<FVector>{}, Value);
+}
+
+void UArcActivityBPFunctionLibrary::SetActorPreviousTaggedData_Event(FArcActivityTagStackChanged& Event, AActor* Value)
+{
+	Event.PreviousValue = FTaggedDataVariant(TInPlaceType<TWeakObjectPtr<AActor>>{}, Value);
+}
+
+bool UArcActivityBPFunctionLibrary::HasPreviousTaggedDataAsInt_Event(const FArcActivityTagStackChanged& Event)
+{
+	return Event.PreviousValue.IsType<int>();
+}
+
+bool UArcActivityBPFunctionLibrary::HasPreviousTaggedDataAsFloat_Event(const FArcActivityTagStackChanged& Event)
+{
+	return Event.PreviousValue.IsType<float>();
+}
+
+bool UArcActivityBPFunctionLibrary::HasPreviousTaggedDataAsDouble_Event(const FArcActivityTagStackChanged& Event)
+{
+	return Event.PreviousValue.IsType<double>();
+}
+
+bool UArcActivityBPFunctionLibrary::HasPreviousTaggedDataAsGameplayTag_Event(const FArcActivityTagStackChanged& Event)
+{
+	return Event.PreviousValue.IsType<FGameplayTag>();
+}
+
+bool UArcActivityBPFunctionLibrary::HasPreviousTaggedDataAsFVector_Event(const FArcActivityTagStackChanged& Event)
+{
+	return Event.PreviousValue.IsType<FVector>();
+}
+
+bool UArcActivityBPFunctionLibrary::HasPreviousTaggedDataAsActor_Event(const FArcActivityTagStackChanged& Event)
+{
+	return Event.PreviousValue.IsType<TWeakObjectPtr<AActor>>();
 }
 

--- a/ArcActivities/Source/ArcActivitiesPlugin/Private/ArcActivityBPFunctionLibrary.cpp
+++ b/ArcActivities/Source/ArcActivitiesPlugin/Private/ArcActivityBPFunctionLibrary.cpp
@@ -1,0 +1,173 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+
+#include "ArcActivityBPFunctionLibrary.h"
+#include "GameplayTagContainer.h"
+#include "ArcActivityInstance.h"
+
+int32 UArcActivityBPFunctionLibrary::GetTaggedDataAsInt(UArcActivityInstance* Activity, FGameplayTag Tag, bool& Found)
+{
+	if (IsValid(Activity))
+	{
+		if (auto Value = Activity->GetTaggedData<int32>(Tag))
+		{
+			return *Value;
+		}
+	}
+	Found = false;
+	return {};
+}
+
+float UArcActivityBPFunctionLibrary::GetTaggedDataAsFloat(UArcActivityInstance* Activity, FGameplayTag Tag, bool& Found)
+{
+	if (IsValid(Activity))
+	{
+		if (auto Value = Activity->GetTaggedData<float>(Tag))
+		{
+			return *Value;
+		}
+	}
+	Found = false;
+	return {};
+}
+
+double UArcActivityBPFunctionLibrary::GetTaggedDataAsDouble(UArcActivityInstance* Activity, FGameplayTag Tag,
+	bool& Found)
+{
+	if (IsValid(Activity))
+	{
+		if (auto Value = Activity->GetTaggedData<double>(Tag))
+		{
+			return *Value;
+		}
+	}
+	Found = false;
+	return {};
+}
+
+FGameplayTag UArcActivityBPFunctionLibrary::GetTaggedDataAsGameplayTag(UArcActivityInstance* Activity, FGameplayTag Tag,
+	bool& Found)
+{
+	if (IsValid(Activity))
+	{
+		if (auto Value = Activity->GetTaggedData<FGameplayTag>(Tag))
+		{
+			return *Value;
+		}
+	}
+	Found = false;
+	return {};
+}
+
+FVector UArcActivityBPFunctionLibrary::GetTaggedDataAsFVector(UArcActivityInstance* Activity, FGameplayTag Tag,
+	bool& Found)
+{
+	if (IsValid(Activity))
+	{
+		if (auto Value = Activity->GetTaggedData<FVector>(Tag))
+		{
+			return *Value;
+		}
+	}
+	Found = false;
+	return {};
+}
+
+AActor* UArcActivityBPFunctionLibrary::GetTaggedDataAsActor(UArcActivityInstance* Activity, FGameplayTag Tag,
+	bool& Found)
+{
+	if (IsValid(Activity))
+	{
+		if (auto Value = Activity->GetTaggedData<TWeakObjectPtr<AActor>>(Tag))
+		{
+			if (Value->IsValid())
+			{
+				return Value->Get();
+			}
+		}
+	}
+	Found = false;
+	return {};
+}
+
+void UArcActivityBPFunctionLibrary::SetIntTaggedData(UArcActivityInstance* Activity, FGameplayTag Tag, int32 Value)
+{
+	if (IsValid(Activity))
+	{
+		Activity->SetTaggedData(Tag, Value);
+	}
+}
+
+void UArcActivityBPFunctionLibrary::SetFloatTaggedData(UArcActivityInstance* Activity, FGameplayTag Tag, float Value)
+{
+	if (IsValid(Activity))
+	{
+		Activity->SetTaggedData(Tag, Value);
+	}
+}
+
+void UArcActivityBPFunctionLibrary::SetDoubleTaggedData(UArcActivityInstance* Activity, FGameplayTag Tag, double Value)
+{
+	if (IsValid(Activity))
+	{
+		Activity->SetTaggedData(Tag, Value);
+	}
+}
+
+void UArcActivityBPFunctionLibrary::SetGameplayTagTaggedData(UArcActivityInstance* Activity, FGameplayTag Tag,
+	FGameplayTag Value)
+{
+	if (IsValid(Activity))
+	{
+		Activity->SetTaggedData(Tag, Value);
+	}
+}
+
+void UArcActivityBPFunctionLibrary::SetFVectorTaggedData(UArcActivityInstance* Activity, FGameplayTag Tag,
+	FVector Value)
+{
+	if (IsValid(Activity))
+	{
+		Activity->SetTaggedData(Tag, Value);
+	}
+}
+
+void UArcActivityBPFunctionLibrary::SetActorTaggedData(UArcActivityInstance* Activity, FGameplayTag Tag, AActor* Value)
+{
+	if (IsValid(Activity))
+	{
+		Activity->SetTaggedData(Tag, TWeakObjectPtr(Value));
+	}
+}
+
+
+bool UArcActivityBPFunctionLibrary::HasTaggedDataAsInt(UArcActivityInstance* Activity, FGameplayTag Tag)
+{
+	return IsValid(Activity) && Activity->HasTaggedData<int32>(Tag);
+}
+
+bool UArcActivityBPFunctionLibrary::HasTaggedDataAsFloat(UArcActivityInstance* Activity, FGameplayTag Tag)
+{
+	return IsValid(Activity) && Activity->HasTaggedData<float>(Tag);
+}
+
+bool UArcActivityBPFunctionLibrary::HasTaggedDataAsDouble(UArcActivityInstance* Activity, FGameplayTag Tag)
+{
+	return IsValid(Activity) && Activity->HasTaggedData<double>(Tag);
+}
+
+bool UArcActivityBPFunctionLibrary::HasTaggedDataAsGameplayTag(UArcActivityInstance* Activity, FGameplayTag Tag)
+{
+	return IsValid(Activity) && Activity->HasTaggedData<FGameplayTag>(Tag);
+}
+
+bool UArcActivityBPFunctionLibrary::HasTaggedDataAsFVector(UArcActivityInstance* Activity, FGameplayTag Tag)
+{
+	return IsValid(Activity) && Activity->HasTaggedData<FVector>(Tag);
+}
+
+bool UArcActivityBPFunctionLibrary::HasTaggedDataAsActor(UArcActivityInstance* Activity, FGameplayTag Tag)
+{
+	return IsValid(Activity) && Activity->HasTaggedData<TWeakObjectPtr<AActor>>(Tag);
+}
+

--- a/ArcActivities/Source/ArcActivitiesPlugin/Private/ArcActivityInstance.cpp
+++ b/ArcActivities/Source/ArcActivitiesPlugin/Private/ArcActivityInstance.cpp
@@ -31,10 +31,12 @@ void UArcActivityInstance::GetOwnedGameplayTags(FGameplayTagContainer& TagContai
 
 UArcActivityInstance::UArcActivityInstance()
 	: Super()
+	, ActivityState(EArcActivitySuccessState::None)
 	, PreviousStageCompletion(EArcActivitySuccessState::None)
 	, PlayersInActivty(this)
 {
-	TagStacks.OnTagCountChanged.AddUObject(this, &ThisClass::OnTagCountChanged);
+	//TODO: Adjust this for tagged variants
+	//TagStacks.OnTagCountChanged.AddUObject(this, &ThisClass::OnTagCountChanged);
 }
 
 UWorld* UArcActivityInstance::GetWorld() const
@@ -67,7 +69,7 @@ void UArcActivityInstance::GetLifetimeReplicatedProps(TArray<class FLifetimeProp
 	DOREPLIFETIME(UArcActivityInstance, PlayersInActivty);
 	DOREPLIFETIME(UArcActivityInstance, ActivityState);
 	DOREPLIFETIME(UArcActivityInstance, PreviousStageCompletion);
-	DOREPLIFETIME(UArcActivityInstance, TagStacks);
+	DOREPLIFETIME(UArcActivityInstance, TaggedData);
 }
 
 bool UArcActivityInstance::IsActive() const
@@ -388,36 +390,6 @@ TArray<UArcActivityPlayerComponent*> UArcActivityInstance::GetPlayersInActivity(
 		Components.AddUnique(Player.Player);
 	}
 	return Components;
-}
-
-void UArcActivityInstance::AddStatTagStack(FGameplayTag Tag, int32 StackCount)
-{
-	TagStacks.AddStack(Tag, StackCount);
-}
-
-void UArcActivityInstance::RemoveStatTagStack(FGameplayTag Tag, int32 StackCount)
-{
-	TagStacks.RemoveStack(Tag, StackCount);
-}
-
-void UArcActivityInstance::SetStatTagStack(FGameplayTag Tag, int32 StackCount)
-{
-	TagStacks.SetStack(Tag, StackCount);
-}
-
-int32 UArcActivityInstance::GetStatTagStackCount(FGameplayTag Tag) const
-{
-	return TagStacks.GetStackCount(Tag);
-}
-
-bool UArcActivityInstance::HasStatTag(FGameplayTag Tag) const
-{
-	return TagStacks.ContainsTag(Tag);
-}
-
-void UArcActivityInstance::ClearStatTag(FGameplayTag Tag)
-{
-	TagStacks.ClearStack(Tag);
 }
 
 void UArcActivityInstance::OnTagCountChanged(FGameplayTag Tag, int32 CurrentValue, int32 PreviousValue) const

--- a/ArcActivities/Source/ArcActivitiesPlugin/Private/ArcActivityInstance.cpp
+++ b/ArcActivities/Source/ArcActivitiesPlugin/Private/ArcActivityInstance.cpp
@@ -35,8 +35,7 @@ UArcActivityInstance::UArcActivityInstance()
 	, PreviousStageCompletion(EArcActivitySuccessState::None)
 	, PlayersInActivty(this)
 {
-	//TODO: Adjust this for tagged variants
-	//TagStacks.OnTagCountChanged.AddUObject(this, &ThisClass::OnTagCountChanged);
+	TaggedData.OnTaggedDataChanged.AddUObject(this, &ThisClass::OnTagDataChanged);
 }
 
 UWorld* UArcActivityInstance::GetWorld() const
@@ -392,9 +391,9 @@ TArray<UArcActivityPlayerComponent*> UArcActivityInstance::GetPlayersInActivity(
 	return Components;
 }
 
-void UArcActivityInstance::OnTagCountChanged(FGameplayTag Tag, int32 CurrentValue, int32 PreviousValue) const
+void UArcActivityInstance::OnTagDataChanged(FGameplayTag Tag, FTaggedDataVariant PreviousValue, bool bRemoved) const
 {
-	RaiseEvent(FArcActivityTagStackChangedEventTag, FArcActivityTagStackChanged( const_cast<UArcActivityInstance*>(this), Tag, CurrentValue, PreviousValue ));
+	RaiseEvent(FArcActivityTagStackChangedEventTag, FArcActivityTagStackChanged( const_cast<UArcActivityInstance*>(this), Tag, PreviousValue, bRemoved ));
 }
 
 bool UArcActivityInstance::InitActivityGraph(UArcActivity* Graph, const FGameplayTagContainer& Tags)

--- a/ArcActivities/Source/ArcActivitiesPlugin/Private/ArcActivityTypes.cpp
+++ b/ArcActivities/Source/ArcActivitiesPlugin/Private/ArcActivityTypes.cpp
@@ -11,170 +11,42 @@ UE_DEFINE_GAMEPLAY_TAG(FArcActivityPlayerChangedEventTag, TEXT("Activity.Event.P
 UE_DEFINE_GAMEPLAY_TAG(FArcActivityTagStackChangedEventTag, TEXT("Activity.Event.TagStackChanged"));
 
 
-
-FString FArcActivityTagStack::GetDebugString() const
+FString FArcActivityTaggedData::GetDebugString() const
 {
-	return FString::Printf(TEXT("%sx%d"), *Tag.ToString(), StackCount);
+	return TEXT("TODO");
 }
 
-void FArcActivityTagStackContainer::AddStack(FGameplayTag Tag, int32 StackCount)
+void FArcActivityTaggedDataContainer::RebuildTagToCountMap()
 {
-	if (!Tag.IsValid())
+	TagToDataMap.Empty(TaggedData.Num());
+	for (const auto& [Tag, Data] : TagToDataMap)
 	{
-		FFrame::KismetExecutionMessage(TEXT("An invalid tag was passed to AddStack"), ELogVerbosity::Warning);
-		return;
-	}
-
-	if (StackCount > 0)
-	{
-		for (FArcActivityTagStack& Stack : Stacks)
-		{
-			if (Stack.Tag == Tag)
-			{
-				const int32 NewCount = Stack.StackCount + StackCount;
-				Stack.StackCount = NewCount;
-				TagToCountMap[Tag] = NewCount;
-				MarkItemDirty(Stack);
-				return;
-			}
-		}
-
-		FArcActivityTagStack& NewStack = Stacks.Emplace_GetRef(Tag, StackCount);
-		MarkItemDirty(NewStack);
-		TagToCountMap.Add(Tag, StackCount);
-		OnTagCountChanged.Broadcast(Tag, StackCount, 0);
+		TagToDataMap.Add(Tag, Data);
 	}
 }
 
-void FArcActivityTagStackContainer::RemoveStack(FGameplayTag Tag, int32 StackCount)
-{
-	if (!Tag.IsValid())
-	{
-		FFrame::KismetExecutionMessage(TEXT("An invalid tag was passed to RemoveStack"), ELogVerbosity::Warning);
-		return;
-	}
-
-	//@TODO: Should we error if you try to remove a stack that doesn't exist or has a smaller count?
-	if (StackCount > 0)
-	{
-		for (auto It = Stacks.CreateIterator(); It; ++It)
-		{
-			FArcActivityTagStack& Stack = *It;
-			if (Stack.Tag == Tag)
-			{
-				if (Stack.StackCount <= StackCount)
-				{
-
-					OnTagCountChanged.Broadcast(Tag, 0, Stack.StackCount);
-					It.RemoveCurrent();
-					TagToCountMap.Remove(Tag);
-					MarkArrayDirty();
-				}
-				else
-				{
-					const int32 OldCount = Stack.StackCount;
-					const int32 NewCount = Stack.StackCount - StackCount;
-					Stack.StackCount = NewCount;
-					TagToCountMap[Tag] = NewCount;
-					MarkItemDirty(Stack);
-					OnTagCountChanged.Broadcast(Tag, NewCount,OldCount);
-				}
-				return;
-			}
-		}
-	}
-}
-
-void FArcActivityTagStackContainer::SetStack(FGameplayTag Tag, int32 StackCount)
-{
-	if (!Tag.IsValid())
-	{
-		FFrame::KismetExecutionMessage(TEXT("An invalid tag was passed to AddStack"), ELogVerbosity::Warning);
-		return;
-	}
-
-	if (StackCount > 0)
-	{
-		for (FArcActivityTagStack& Stack : Stacks)
-		{
-			if (Stack.Tag == Tag)
-			{
-				const int32 OldCount = Stack.StackCount;
-				Stack.StackCount = StackCount;
-				TagToCountMap[Tag] = StackCount;
-				MarkItemDirty(Stack);
-				OnTagCountChanged.Broadcast(Tag, StackCount, OldCount);
-				return;
-			}
-		}
-
-		FArcActivityTagStack& NewStack = Stacks.Emplace_GetRef(Tag, StackCount);
-		MarkItemDirty(NewStack);
-		TagToCountMap.Add(Tag, StackCount);
-		OnTagCountChanged.Broadcast(Tag, StackCount, 0);
-	}
-}
-
-void FArcActivityTagStackContainer::ClearStack(FGameplayTag Tag)
-{
-	if (!Tag.IsValid())
-	{
-		FFrame::KismetExecutionMessage(TEXT("An invalid tag was passed to Clear Stack"), ELogVerbosity::Warning);
-		return;
-	}
-
-
-	for (auto It = Stacks.CreateIterator(); It; ++It)
-	{
-		FArcActivityTagStack& Stack = *It;
-		if (Stack.Tag == Tag)
-		{
-			OnTagCountChanged.Broadcast(Tag, 0, Stack.StackCount);
-			It.RemoveCurrent();
-			TagToCountMap.Remove(Tag);
-			MarkArrayDirty();
-		}
-	}
-}
-
-void FArcActivityTagStackContainer::RebuildTagToCountMap()
-{
-	TagToCountMap.Empty(Stacks.Num());
-	for (const auto& Stack : Stacks)
-	{
-		TagToCountMap.Add(Stack.Tag, Stack.StackCount);
-	}
-}
-
-void FArcActivityTagStackContainer::PreReplicatedRemove(const TArrayView<int32> RemovedIndices, int32 FinalSize)
+void FArcActivityTaggedDataContainer::PreReplicatedRemove(const TArrayView<int32> RemovedIndices, int32 FinalSize)
 {
 	for (int32 Index : RemovedIndices)
 	{
-		const FGameplayTag Tag = Stacks[Index].Tag;
-		TagToCountMap.Remove(Tag);
-		OnTagCountChanged.Broadcast(Tag, 0, Stacks[Index].StackCount);
+
 	}
 }
 
-void FArcActivityTagStackContainer::PostReplicatedAdd(const TArrayView<int32> AddedIndices, int32 FinalSize)
+void FArcActivityTaggedDataContainer::PostReplicatedAdd(const TArrayView<int32> AddedIndices, int32 FinalSize)
 {
 	for (int32 Index : AddedIndices)
 	{
-		const FArcActivityTagStack& Stack = Stacks[Index];
-		TagToCountMap.Add(Stack.Tag, Stack.StackCount);
-		OnTagCountChanged.Broadcast(Stack.Tag, Stacks[Index].StackCount, 0);
+
 	}
 }
 
-void FArcActivityTagStackContainer::PostReplicatedChange(const TArrayView<int32> ChangedIndices, int32 FinalSize)
+void FArcActivityTaggedDataContainer::PostReplicatedChange(const TArrayView<int32> ChangedIndices, int32 FinalSize)
 {
 	for (int32 Index : ChangedIndices)
 	{
 		
-		const FArcActivityTagStack& Stack = Stacks[Index];
-		const int32 OldCount = TagToCountMap.FindRef(Stack.Tag);
-		TagToCountMap[Stack.Tag] = Stack.StackCount;
-		OnTagCountChanged.Broadcast(Stack.Tag, Stack.StackCount, OldCount);
+
 	}
 }
 

--- a/ArcActivities/Source/ArcActivitiesPlugin/Private/ArcActivityTypes.cpp
+++ b/ArcActivities/Source/ArcActivitiesPlugin/Private/ArcActivityTypes.cpp
@@ -29,7 +29,9 @@ void FArcActivityTaggedDataContainer::PreReplicatedRemove(const TArrayView<int32
 {
 	for (int32 Index : RemovedIndices)
 	{
-
+		const FGameplayTag Tag = TaggedData[Index].Tag;
+		TagToDataMap.Remove(Tag);
+		OnTaggedDataChanged.Broadcast(Tag, TaggedData[Index].Value, true);
 	}
 }
 
@@ -37,7 +39,9 @@ void FArcActivityTaggedDataContainer::PostReplicatedAdd(const TArrayView<int32> 
 {
 	for (int32 Index : AddedIndices)
 	{
-
+		const FArcActivityTaggedData& Data = TaggedData[Index];
+		TagToDataMap.Add(Data.Tag, Data.Value);
+		OnTaggedDataChanged.Broadcast(Data.Tag, FTaggedDataVariant{}, false);
 	}
 }
 
@@ -45,7 +49,10 @@ void FArcActivityTaggedDataContainer::PostReplicatedChange(const TArrayView<int3
 {
 	for (int32 Index : ChangedIndices)
 	{
-		
+		const FArcActivityTaggedData& Data = TaggedData[Index];
+		FTaggedDataVariant OldData = TagToDataMap.FindRef(Data.Tag);
+		TagToDataMap[Data.Tag] = Data.Value;
+		OnTaggedDataChanged.Broadcast(Data.Tag, OldData, false);
 
 	}
 }

--- a/ArcActivities/Source/ArcActivitiesPlugin/Private/ArcActivityTypes.cpp
+++ b/ArcActivities/Source/ArcActivitiesPlugin/Private/ArcActivityTypes.cpp
@@ -11,6 +11,14 @@ UE_DEFINE_GAMEPLAY_TAG(FArcActivityPlayerChangedEventTag, TEXT("Activity.Event.P
 UE_DEFINE_GAMEPLAY_TAG(FArcActivityTagStackChangedEventTag, TEXT("Activity.Event.TagStackChanged"));
 
 
+bool FArcActivityTaggedData::NetSerialize(FArchive& Ar, class UPackageMap* Map, bool& bOutSuccess)
+{
+	Tag.NetSerialize(Ar, Map, bOutSuccess);
+	Ar << Value;
+	bOutSuccess = true;
+	return true;
+}
+
 FString FArcActivityTaggedData::GetDebugString() const
 {
 	return TEXT("TODO");

--- a/ArcActivities/Source/ArcActivitiesPlugin/Public/ArcActivityBPFunctionLibrary.h
+++ b/ArcActivities/Source/ArcActivitiesPlugin/Public/ArcActivityBPFunctionLibrary.h
@@ -4,6 +4,7 @@
 
 #include "CoreMinimal.h"
 #include "Kismet/BlueprintFunctionLibrary.h"
+#include "ArcActivityTypes.h"
 #include "ArcActivityBPFunctionLibrary.generated.h"
 
 
@@ -67,6 +68,57 @@ public:
 	static bool HasTaggedDataAsFVector(UArcActivityInstance* Activity, FGameplayTag Tag);
 	UFUNCTION(BlueprintCallable, Category = "Activity")
 	static bool HasTaggedDataAsActor(UArcActivityInstance* Activity, FGameplayTag Tag);
+
+	// Returns the tagged data of an activity event as an integer
+	UFUNCTION(BlueprintCallable, Category = "Activity", meta=(ExpandBoolAsExecs="Found"))
+	static int32 GetPreviousTaggedDataAsInt_Event(const FArcActivityTagStackChanged& Event, bool& Found);
+
+	// Returns the tagged data of an activity event as a float
+	UFUNCTION(BlueprintCallable, Category = "Activity", meta=(ExpandBoolAsExecs="Found"))
+	static float GetPreviousTaggedDataAsFloat_Event(const FArcActivityTagStackChanged& Event, bool& Found);
+
+	// Returns the tagged data of an activity event as a double
+	UFUNCTION(BlueprintCallable, Category = "Activity", meta=(ExpandBoolAsExecs="Found"))
+	static double GetPreviousTaggedDataAsDouble_Event(const FArcActivityTagStackChanged& Event, bool& Found);
+
+	// Returns the tagged data of an activity event as a Gameplay Tag
+	UFUNCTION(BlueprintCallable, Category = "Activity", meta=(ExpandBoolAsExecs="Found"))
+	static FGameplayTag GetPreviousTaggedDataAsGameplayTag_Event(const FArcActivityTagStackChanged& Event, bool& Found);
+
+	// Returns the tagged data of an activity event as a Vector
+	UFUNCTION(BlueprintCallable, Category = "Activity", meta=(ExpandBoolAsExecs="Found"))
+	static FVector GetPreviousTaggedDataAsFVector_Event(const FArcActivityTagStackChanged& Event, bool& Found);
+
+	// Returns the tagged data of an activity event as an Actor
+	UFUNCTION(BlueprintCallable, Category = "Activity", meta=(ExpandBoolAsExecs="Found"))
+	static AActor* GetPreviousTaggedDataAsActor_Event(const FArcActivityTagStackChanged& Event, bool& Found);
+
+	UFUNCTION(BlueprintCallable, Category = "Activity")
+	static void SetIntPreviousTaggedData_Event(UPARAM(ref) FArcActivityTagStackChanged& Event, int32 Value);
+
+	UFUNCTION(BlueprintCallable, Category = "Activity")
+	static void SetFloatPreviousTaggedData_Event(UPARAM(ref) FArcActivityTagStackChanged& Event, float Value);
+	UFUNCTION(BlueprintCallable, Category = "Activity")
+	static void SetDoublePreviousTaggedData_Event(UPARAM(ref) FArcActivityTagStackChanged& Event, double Value);
+	UFUNCTION(BlueprintCallable, Category = "Activity")
+	static void SetGameplayTagPreviousTaggedData_Event(UPARAM(ref) FArcActivityTagStackChanged& Event, FGameplayTag Value);
+	UFUNCTION(BlueprintCallable, Category = "Activity")
+	static void SetFVectorPreviousTaggedData_Event(UPARAM(ref) FArcActivityTagStackChanged& Event, FVector Value);
+	UFUNCTION(BlueprintCallable, Category = "Activity")
+	static void SetActorPreviousTaggedData_Event(UPARAM(ref) FArcActivityTagStackChanged& Event, AActor* Value);
+
 	
+	UFUNCTION(BlueprintCallable, Category = "Activity")
+	static bool HasPreviousTaggedDataAsInt_Event(const FArcActivityTagStackChanged& Event);
+	UFUNCTION(BlueprintCallable, Category = "Activity")
+	static bool HasPreviousTaggedDataAsFloat_Event(const FArcActivityTagStackChanged& Event);
+	UFUNCTION(BlueprintCallable, Category = "Activity")
+	static bool HasPreviousTaggedDataAsDouble_Event(const FArcActivityTagStackChanged& Event);
+	UFUNCTION(BlueprintCallable, Category = "Activity")
+	static bool HasPreviousTaggedDataAsGameplayTag_Event(const FArcActivityTagStackChanged& Event);
+	UFUNCTION(BlueprintCallable, Category = "Activity")
+	static bool HasPreviousTaggedDataAsFVector_Event(const FArcActivityTagStackChanged& Event);
+	UFUNCTION(BlueprintCallable, Category = "Activity")
+	static bool HasPreviousTaggedDataAsActor_Event(const FArcActivityTagStackChanged& Event);
 	
 };

--- a/ArcActivities/Source/ArcActivitiesPlugin/Public/ArcActivityBPFunctionLibrary.h
+++ b/ArcActivities/Source/ArcActivitiesPlugin/Public/ArcActivityBPFunctionLibrary.h
@@ -1,0 +1,72 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Kismet/BlueprintFunctionLibrary.h"
+#include "ArcActivityBPFunctionLibrary.generated.h"
+
+
+class UArcActivityInstance;
+/**
+ * 
+ */
+UCLASS()
+class ARCACTIVITIESPLUGIN_API UArcActivityBPFunctionLibrary : public UBlueprintFunctionLibrary
+{
+	GENERATED_BODY()
+public:
+	// Returns the tagged data of an activity instance as an integer
+	UFUNCTION(BlueprintCallable, Category = "Activity", meta=(ExpandBoolAsExecs="Found"))
+	static int32 GetTaggedDataAsInt(UArcActivityInstance* Activity, FGameplayTag Tag, bool& Found);
+
+	// Returns the tagged data of an activity instance as a float
+	UFUNCTION(BlueprintCallable, Category = "Activity", meta=(ExpandBoolAsExecs="Found"))
+	static float GetTaggedDataAsFloat(UArcActivityInstance* Activity, FGameplayTag Tag, bool& Found);
+
+	// Returns the tagged data of an activity instance as a double
+	UFUNCTION(BlueprintCallable, Category = "Activity", meta=(ExpandBoolAsExecs="Found"))
+	static double GetTaggedDataAsDouble( UArcActivityInstance* Activity, FGameplayTag Tag, bool& Found);
+
+	// Returns the tagged data of an activity instance as a Gameplay Tag
+	UFUNCTION(BlueprintCallable, Category = "Activity", meta=(ExpandBoolAsExecs="Found"))
+	static FGameplayTag GetTaggedDataAsGameplayTag(UArcActivityInstance* Activity, FGameplayTag Tag, bool& Found);
+
+	// Returns the tagged data of an activity instance as a Vector
+	UFUNCTION(BlueprintCallable, Category = "Activity", meta=(ExpandBoolAsExecs="Found"))
+	static FVector GetTaggedDataAsFVector(UArcActivityInstance* Activity, FGameplayTag Tag, bool& Found);
+
+	// Returns the tagged data of an activity instance as an Actor
+	UFUNCTION(BlueprintCallable, Category = "Activity", meta=(ExpandBoolAsExecs="Found"))
+	static AActor* GetTaggedDataAsActor(UArcActivityInstance* Activity, FGameplayTag Tag, bool& Found);
+
+	UFUNCTION(BlueprintCallable, Category = "Activity")
+	static void SetIntTaggedData(UArcActivityInstance* Activity, FGameplayTag Tag, int32 Value);
+
+	UFUNCTION(BlueprintCallable, Category = "Activity")
+	static void SetFloatTaggedData(UArcActivityInstance* Activity, FGameplayTag Tag, float Value);
+	UFUNCTION(BlueprintCallable, Category = "Activity")
+	static void SetDoubleTaggedData(UArcActivityInstance* Activity, FGameplayTag Tag, double Value);
+	UFUNCTION(BlueprintCallable, Category = "Activity")
+	static void SetGameplayTagTaggedData(UArcActivityInstance* Activity, FGameplayTag Tag, FGameplayTag Value);
+	UFUNCTION(BlueprintCallable, Category = "Activity")
+	static void SetFVectorTaggedData(UArcActivityInstance* Activity, FGameplayTag Tag, FVector Value);
+	UFUNCTION(BlueprintCallable, Category = "Activity")
+	static void SetActorTaggedData(UArcActivityInstance* Activity, FGameplayTag Tag, AActor* Value);
+
+	
+	UFUNCTION(BlueprintCallable, Category = "Activity")
+	static bool HasTaggedDataAsInt(UArcActivityInstance* Activity, FGameplayTag Tag);
+	UFUNCTION(BlueprintCallable, Category = "Activity")
+	static bool HasTaggedDataAsFloat(UArcActivityInstance* Activity, FGameplayTag Tag);
+	UFUNCTION(BlueprintCallable, Category = "Activity")
+	static bool HasTaggedDataAsDouble(UArcActivityInstance* Activity, FGameplayTag Tag);
+	UFUNCTION(BlueprintCallable, Category = "Activity")
+	static bool HasTaggedDataAsGameplayTag(UArcActivityInstance* Activity, FGameplayTag Tag);
+	UFUNCTION(BlueprintCallable, Category = "Activity")
+	static bool HasTaggedDataAsFVector(UArcActivityInstance* Activity, FGameplayTag Tag);
+	UFUNCTION(BlueprintCallable, Category = "Activity")
+	static bool HasTaggedDataAsActor(UArcActivityInstance* Activity, FGameplayTag Tag);
+	
+	
+};

--- a/ArcActivities/Source/ArcActivitiesPlugin/Public/ArcActivityInstance.h
+++ b/ArcActivities/Source/ArcActivitiesPlugin/Public/ArcActivityInstance.h
@@ -107,9 +107,15 @@ public:
 		return TaggedData.GetTaggedData<T>(Tag);
 	}
 
+	bool HasAnyTaggedData(FGameplayTag Tag) const
+	{
+		return TaggedData.HasAnyTaggedData(Tag);
+	}
+
+	template<typename T>
 	bool HasTaggedData(FGameplayTag Tag) const
 	{
-		return TaggedData.HasTaggedData(Tag);
+		return TaggedData.HasTaggedData<T>(Tag);
 	}
 
 

--- a/ArcActivities/Source/ArcActivitiesPlugin/Public/ArcActivityInstance.h
+++ b/ArcActivities/Source/ArcActivitiesPlugin/Public/ArcActivityInstance.h
@@ -122,7 +122,7 @@ public:
 	
 
 protected:
-	void OnTagCountChanged(FGameplayTag Tag, int32 CurrentValue, int32 PreviousValue) const;
+	void OnTagDataChanged(FGameplayTag Tag, FTaggedDataVariant PreviousValue, bool bRemoved) const;
 
 	template<typename T>
 	void RaiseEvent(FGameplayTag Tag, const T& EventStruct) const;

--- a/ArcActivities/Source/ArcActivitiesPlugin/Public/ArcActivityInstance.h
+++ b/ArcActivities/Source/ArcActivitiesPlugin/Public/ArcActivityInstance.h
@@ -89,29 +89,31 @@ public:
 	UFUNCTION(BlueprintCallable, Category = "Arc|Activity")
 	TArray<UArcActivityPlayerComponent*> GetPlayersInActivity() const;
 
-	// Adds a specified number of stacks to the tag (does nothing if StackCount is below 1)
-	UFUNCTION(BlueprintCallable, BlueprintAuthorityOnly, Category = "Arc|Activity")
-	void AddStatTagStack(FGameplayTag Tag, int32 StackCount);
 
-	// Removes a specified number of stacks from the tag (does nothing if StackCount is below 1)
-	UFUNCTION(BlueprintCallable, BlueprintAuthorityOnly, Category = "Arc|Activity")
-	void RemoveStatTagStack(FGameplayTag Tag, int32 StackCount);
+	template<typename T>
+	void SetTaggedData(FGameplayTag Tag, T Value) 
+	{
+		TaggedData.SetTaggedData(Tag, Value);
+	}
 
-	// Sets a stat tag stack
-	UFUNCTION(BlueprintCallable, BlueprintAuthorityOnly, Category = "Arc|Activity")
-	void SetStatTagStack(FGameplayTag Tag, int32 StackCount);
+	void ClearTaggedData(FGameplayTag Tag) 
+	{
+		TaggedData.ClearTaggedData(Tag);
+	}
 
-	// Returns the stack count of the specified tag (or 0 if the tag is not present)
-	UFUNCTION(BlueprintCallable, Category = "Arc|Activity")
-	int32 GetStatTagStackCount(FGameplayTag Tag) const;
+	template<typename T>
+	TOptional<T> GetTaggedData(FGameplayTag Tag) const
+	{
+		return TaggedData.GetTaggedData<T>(Tag);
+	}
 
-	// Returns true if there is at least one stack of the specified tag
-	UFUNCTION(BlueprintCallable, Category = "Arc|Activity")
-	bool HasStatTag(FGameplayTag Tag) const;
+	bool HasTaggedData(FGameplayTag Tag) const
+	{
+		return TaggedData.HasTaggedData(Tag);
+	}
 
-	UFUNCTION(BlueprintCallable, Category = "Arc|Activity")
-	void ClearStatTag(FGameplayTag Tag);
 
+	
 
 protected:
 	void OnTagCountChanged(FGameplayTag Tag, int32 CurrentValue, int32 PreviousValue) const;
@@ -151,7 +153,7 @@ private:
 	TObjectPtr<UArcActivityStage> CurrentStage;
 
 	UPROPERTY(Replicated)
-	FArcActivityTagStackContainer TagStacks;
+	FArcActivityTaggedDataContainer TaggedData;
 	
 	UPROPERTY(Replicated)
 	FGameplayTagContainer ActivityTags;

--- a/ArcActivities/Source/ArcActivitiesPlugin/Public/ArcActivityTypes.h
+++ b/ArcActivities/Source/ArcActivitiesPlugin/Public/ArcActivityTypes.h
@@ -280,15 +280,15 @@ public:
 			return Data.Tag == Tag;
 		}))
 		{
-			Data->Value.template Emplace<T>(Value);
+			Data->Value = FTaggedDataVariant(TInPlaceType<T>{}, Value);
 			MarkItemDirty(*Data);
-			TagToDataMap[Tag].Emplace<T>(Value);
+			TagToDataMap.FindOrAdd(Tag, FTaggedDataVariant(TInPlaceType<T>{}, Value));
 		}
 		else
 		{
-			FArcActivityTaggedData&  EmplacedData = TaggedData.Emplace_GetRef(Tag, Value);
+			FArcActivityTaggedData&  EmplacedData = TaggedData.Add_GetRef(FArcActivityTaggedData(Tag, FTaggedDataVariant(TInPlaceType<T>{}, Value)));
 			MarkItemDirty(EmplacedData);
-			TagToDataMap[Tag].Emplace<T>(Value);
+			TagToDataMap.Add(Tag, FTaggedDataVariant(TInPlaceType<T>{}, Value));
 		}
 	}
 
@@ -323,9 +323,19 @@ public:
 		return {};
 	}
 
-	bool HasTaggedData(FGameplayTag Tag) const
+	bool HasAnyTaggedData(FGameplayTag Tag) const
 	{
 		return TagToDataMap.Contains(Tag);
+	}
+
+	template<typename T>
+	bool HasTaggedData(FGameplayTag Tag) const 
+	{
+		if (auto* Data = TagToDataMap.Find(Tag))
+		{
+			return Data->IsType<T>();
+		}
+		return false;
 	}
 	
 	void RebuildTagToCountMap();

--- a/ArcActivities/Source/ArcActivitiesPluginEditor/Private/ActivitiesPluginEditorModule.cpp
+++ b/ArcActivities/Source/ArcActivitiesPluginEditor/Private/ActivitiesPluginEditorModule.cpp
@@ -28,7 +28,7 @@
 
 
 
-IMPLEMENT_MODULE(FActivitiesPluginEditorModule, ActivitiesPluginEditor)
+IMPLEMENT_MODULE(FActivitiesPluginEditorModule, ArcActivitiesPluginEditor)
 
 class FGraphPanelNodeFactory_ActivityNodes : public FGraphPanelNodeFactory
 {

--- a/ArcActivities/Source/ArcActivitiesPluginEditor/Private/ActivityEditorTypes.cpp
+++ b/ArcActivities/Source/ArcActivitiesPluginEditor/Private/ActivityEditorTypes.cpp
@@ -70,7 +70,7 @@ FString FArcGraphNodeClassData::ToString() const
 		const int32 ShortNameIdx = ClassDesc.Find(TEXT("_"), ESearchCase::CaseSensitive);
 		if (ShortNameIdx != INDEX_NONE)
 		{
-			ClassDesc.MidInline(ShortNameIdx + 1, MAX_int32, false);
+			ClassDesc.MidInline(ShortNameIdx + 1, MAX_int32, EAllowShrinking::No);
 		}
 
 		return ClassDesc;

--- a/ArcActivities/Source/ArcActivitiesPluginEditor/Private/Widgets/SGraphNode_ActivityStage.cpp
+++ b/ArcActivities/Source/ArcActivitiesPluginEditor/Private/Widgets/SGraphNode_ActivityStage.cpp
@@ -518,7 +518,7 @@ void SGraphNode_Activity::AddSubnodesToSetRecursively(TSet<TSharedRef<SWidget>>&
 	}
 }
 
-void SGraphNode_Activity::MoveTo(const FVector2D& NewPosition, FNodeSet& NodeFilter, bool bMarkDirty)
+void SGraphNode_Activity::MoveTo(const FVector2f& NewPosition, FNodeSet& NodeFilter, bool bMarkDirty)
 {
 	SGraphNodeAI::MoveTo(NewPosition, NodeFilter, bMarkDirty);
 

--- a/ArcActivities/Source/ArcActivitiesPluginEditor/Private/Widgets/SGraphNode_ActivityStage.h
+++ b/ArcActivities/Source/ArcActivitiesPluginEditor/Private/Widgets/SGraphNode_ActivityStage.h
@@ -49,7 +49,7 @@ public:
 	virtual TSharedRef<SGraphNode> GetNodeUnderMouse(const FGeometry& MyGeometry, const FPointerEvent& MouseEvent) override;
 	TSharedPtr<SGraphNode> ArcGetSubNodeUnderCursor(const FGeometry& WidgetGeometry, const FPointerEvent& MouseEvent);
 	void AddSubnodesToSetRecursively(TSet< TSharedRef<SWidget> >& Set);
-	virtual void MoveTo(const FVector2D& NewPosition, FNodeSet& NodeFilter, bool bMarkDirty) override;
+	virtual void MoveTo(const FVector2f& NewPosition, FNodeSet& NodeFilter, bool bMarkDirty) override;
 	// End of SGraphNode interface
 
 	/** handle double click */


### PR DESCRIPTION
Previously, we stored integers tagged by gameplay tags as a way for activities to track data as a bit of a blackboard.  This is limiting and there are many other elements that need to be tracked.  

Thus, the tagged stack container has been reworked into a tagged variant that can hold a variety of data.  Accessors are provided for blueprint to be able to access data stored in the variant because TVariant<> isn't exposed to blueprint.  